### PR TITLE
Don't post duplicate spam report

### DIFF
--- a/Phamhilator.UI/Program.cs
+++ b/Phamhilator.UI/Program.cs
@@ -289,12 +289,6 @@ namespace Phamhilator.UI
             Message message = null;
             Report chatMessage = null;
 
-            if (Stats.ReportedUsers.Any(spammer => spammer.Name == p.AuthorName && spammer.Site == p.Site))
-            {
-                message = Config.PrimaryRoom.PostMessage("**Spam**" + messageBody);
-                chatMessage = new Report { Message = message, Post = p, Analysis = info };
-            }
-
             if (info.Type == PostType.Clean)
             {
                 Stats.PostsCaught++;
@@ -332,6 +326,15 @@ namespace Phamhilator.UI
                 case PostType.Spam:
                 {
                     chatMessage = new Report { Message = message, Post = p, Analysis = info };
+                    break;
+                }
+
+                default:
+                {
+                    if (Stats.ReportedUsers.Any(spammer => spammer.Name == p.AuthorName && spammer.Site == p.Site))
+                    {
+                        chatMessage = new Report { Message = message, Post = p, Analysis = info };
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
Spam messages were reported twice due to this statement. Removing this if
statement should avoid it, and the report will still be posted anyway.